### PR TITLE
Use release-drafter to create release draft automatically

### DIFF
--- a/.github/workflows/cui_build.yml
+++ b/.github/workflows/cui_build.yml
@@ -35,6 +35,8 @@ jobs:
       APP_NAME: 'csv-to-sql'
     outputs:
       version: ${{ steps.cargo-metadate.outputs.version }}
+      app_name_prefix: ${{ env.APP_NAME }}-v${{ steps.cargo-metadate.outputs.version }}-build-
+      targets: ${{ matrix.target }}
     steps:
       -
         name: Fetch Sources
@@ -98,3 +100,28 @@ jobs:
           tag: ${{ needs.build.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  attach_assets_to_release_draft:
+    name: Prepare Release Draft
+    needs: [build, prepare_release_draft]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: ${{ needs.build.outputs.targets }}
+    steps:
+      -
+        name: Download Release Asset
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.app_name_prefix }}${{ matrix.target }}
+      -
+        name: Upload Release Asset #ここで成果物をリリースノートにアップロード
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.prepare_release_draft.outputs.upload_url }} 
+          asset_path: ./${{ needs.build.outputs.app_name_prefix }}${{ matrix.target }}.zip
+          asset_name: ${{ needs.build.outputs.app_name_prefix }}${{ matrix.target }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/cui_build.yml
+++ b/.github/workflows/cui_build.yml
@@ -109,6 +109,7 @@ jobs:
       -
         name: Download Release Asset
         uses: actions/download-artifact@v3
+        id: asset
         with:
           name: ${{ needs.build.outputs.app_name_prefix }}${{ needs.build.outputs.targets }}
       -
@@ -119,6 +120,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.prepare_release_draft.outputs.upload_url }} 
-          asset_path: ./${{ needs.build.outputs.app_name_prefix }}${{ needs.build.outputs.targets }}.zip
+          asset_path: ${{ steps.asset.outputs.download-path }}
           asset_name: ${{ needs.build.outputs.app_name_prefix }}${{ needs.build.outputs.targets }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/cui_build.yml
+++ b/.github/workflows/cui_build.yml
@@ -105,15 +105,12 @@ jobs:
     name: Prepare Release Draft
     needs: [build, prepare_release_draft]
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: ${{ needs.build.outputs.targets }}
     steps:
       -
         name: Download Release Asset
         uses: actions/download-artifact@v3
         with:
-          name: ${{ needs.build.outputs.app_name_prefix }}${{ matrix.target }}
+          name: ${{ needs.build.outputs.app_name_prefix }}${{ needs.build.outputs.targets }}
       -
         name: Upload Release Asset #ここで成果物をリリースノートにアップロード
         id: upload-release-asset 
@@ -122,6 +119,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.prepare_release_draft.outputs.upload_url }} 
-          asset_path: ./${{ needs.build.outputs.app_name_prefix }}${{ matrix.target }}.zip
-          asset_name: ${{ needs.build.outputs.app_name_prefix }}${{ matrix.target }}.zip
+          asset_path: ./${{ needs.build.outputs.app_name_prefix }}${{ needs.build.outputs.targets }}.zip
+          asset_name: ${{ needs.build.outputs.app_name_prefix }}${{ needs.build.outputs.targets }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/cui_build.yml
+++ b/.github/workflows/cui_build.yml
@@ -35,8 +35,8 @@ jobs:
       APP_NAME: 'csv-to-sql'
     outputs:
       version: ${{ steps.cargo-metadate.outputs.version }}
-      app_name_prefix: ${{ env.APP_NAME }}-v${{ steps.cargo-metadate.outputs.version }}-build-
-      targets: ${{ matrix.target }}
+      app_name: ${{ env.APP_NAME }}
+      uploaded_name_prefix: ${{ env.APP_NAME }}-v${{ steps.cargo-metadate.outputs.version }}-build-
     steps:
       -
         name: Fetch Sources
@@ -105,17 +105,32 @@ jobs:
     name: Attach Assets to Release Draft
     needs: [build, prepare_release_draft]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-musl
+          - x86_64-pc-windows-msvc
+        include:
+          - target: x86_64-unknown-linux-musl
+            file_extention: ""
+          - target: x86_64-pc-windows-msvc
+            file_extention: ".exe"
     steps:
       -
         name: Download Release Asset
         uses: actions/download-artifact@v3
         id: asset
         with:
-          name: ${{ needs.build.outputs.app_name_prefix }}${{ needs.build.outputs.targets }}
-          path: ~/download/path
+          name: ${{ needs.build.outputs.uploaded_name_prefix }}${{ matrix.target }}
+          path: ~/download/${{ needs.build.outputs.uploaded_name_prefix }}${{ matrix.target }}
       -
         name: Display structure of downloaded files
         run: ls -R
+        working-directory: ${{ steps.asset.outputs.download-path }}
+      - 
+        name: zip assets
+        run: zip -j ${{ needs.build.outputs.uploaded_name_prefix }}${{ matrix.target }}.zip ${{ needs.build.outputs.app_name }}${{ matrix.file_extention }}
         working-directory: ${{ steps.asset.outputs.download-path }}
       -
         name: Upload Release Asset #ここで成果物をリリースノートにアップロード
@@ -125,6 +140,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.prepare_release_draft.outputs.upload_url }} 
-          asset_path: ${{ steps.asset.outputs.download-path }}/${{ needs.build.outputs.app_name_prefix }}${{ needs.build.outputs.targets }}
-          asset_name: ${{ needs.build.outputs.app_name_prefix }}${{ needs.build.outputs.targets }}.zip
+          asset_path: ${{ steps.asset.outputs.download-path }}/${{ needs.build.outputs.uploaded_name_prefix }}${{ matrix.target }}.zip
+          asset_name: ${{ needs.build.outputs.uploaded_name_prefix }}${{ matrix.target }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/cui_build.yml
+++ b/.github/workflows/cui_build.yml
@@ -102,7 +102,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   attach_assets_to_release_draft:
-    name: Prepare Release Draft
+    name: Attach Assets to Release Draft
     needs: [build, prepare_release_draft]
     runs-on: ubuntu-latest
     steps:
@@ -112,14 +112,19 @@ jobs:
         id: asset
         with:
           name: ${{ needs.build.outputs.app_name_prefix }}${{ needs.build.outputs.targets }}
+          path: ~/download/path
+      -
+        name: Display structure of downloaded files
+        run: ls -R
+        working-directory: ${{ steps.asset.outputs.download-path }}
       -
         name: Upload Release Asset #ここで成果物をリリースノートにアップロード
         id: upload-release-asset 
-        uses: actions/upload-release-asset@v1
+        uses: shogo82148/actions-upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.prepare_release_draft.outputs.upload_url }} 
-          asset_path: ${{ steps.asset.outputs.download-path }}
+          asset_path: ${{ steps.asset.outputs.download-path }}/${{ needs.build.outputs.app_name_prefix }}${{ needs.build.outputs.targets }}
           asset_name: ${{ needs.build.outputs.app_name_prefix }}${{ needs.build.outputs.targets }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/cui_build.yml
+++ b/.github/workflows/cui_build.yml
@@ -104,6 +104,9 @@ jobs:
   attach_assets_to_release_draft:
     name: Attach Assets to Release Draft
     needs: [build, prepare_release_draft]
+    permissions:
+      # write permission is required to create a github release
+      contents: write
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/cui_build.yml
+++ b/.github/workflows/cui_build.yml
@@ -75,6 +75,12 @@ jobs:
   prepare_release_draft:
     name: Prepare Release Draft
     needs: [build]
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create-draft.outputs.upload_url }}

--- a/.github/workflows/cui_test.yml
+++ b/.github/workflows/cui_test.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'main'
       - 'develop'
+      - 'feature/**'
     paths:
       - 'src/*'
       - '.github/workflows/cui_test.yml'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -86,6 +86,17 @@ jobs:
       -
         name: Fetch Sources
         uses: actions/checkout@v3
+      # Remove old release drafts by using the curl request for the available releases with draft flag
+      -
+        name: Remove Old Release Drafts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -H "Authorization: Bearer ${GITHUB_TOKEN}" https://api.github.com/repos/$GITHUB_REPOSITORY/releases \
+            | tr '\r\n' ' ' \
+            | jq '.[] | select(.draft == true) | .id' \
+            | xargs -I '{}' \
+          curl -X DELETE -H "Authorization: Bearer ${GITHUB_TOKEN}" https://api.github.com/repos/$GITHUB_REPOSITORY/releases/{}
       -
         name: Create/Update Release Draft #ここでリリースノートを作成
         id: create-draft

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -102,9 +102,10 @@ jobs:
         id: create-draft
         uses: release-drafter/release-drafter@v5
         with:
-          version: ${{ needs.build.outputs.version }}
-          name: ${{ needs.build.outputs.version }}
-          tag: ${{ needs.build.outputs.version }}
+          commitish: main
+          version: v${{ needs.build.outputs.version }}
+          name: v${{ needs.build.outputs.version }}
+          tag: v${{ needs.build.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,12 +3,8 @@ on:
   push:
     branches:
       - 'main'
-      - 'develop'
-    paths:
-      - 'src/*'
-      - '.github/workflows/cui_build.yml'
-  # pull_request:
-  #   types: [opened, reopened, synchronize]
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:
@@ -95,9 +91,9 @@ jobs:
         id: create-draft
         uses: release-drafter/release-drafter@v5
         with:
-          version: ${{ needs.build.outputs.version }}
-          name: ${{ needs.build.outputs.version }}
-          tag: ${{ needs.build.outputs.version }}
+          version: v${{ needs.build.outputs.version }}
+          name: v${{ needs.build.outputs.version }}
+          tag: v${{ needs.build.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -91,9 +91,9 @@ jobs:
         id: create-draft
         uses: release-drafter/release-drafter@v5
         with:
-          version: v${{ needs.build.outputs.version }}
-          name: v${{ needs.build.outputs.version }}
-          tag: v${{ needs.build.outputs.version }}
+          version: ${{ needs.build.outputs.version }}
+          name: ${{ needs.build.outputs.version }}
+          tag: ${{ needs.build.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,4 @@
-name: cui_build
+name: release-drafter
 on:
   push:
     branches:


### PR DESCRIPTION
リリースノート草稿の自動作成のため、[release-drafter/release-drafter](https://github.com/release-drafter/release-drafter)を利用するようにした。
また、ビルドした成果物も自動的に添付されるよう、[shogo82148/actions-upload-release-asset](https://github.com/shogo82148/actions-upload-release-asset) も利用している。